### PR TITLE
fix: my_server_block content and values

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.27.8
+version: 3.27.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.26.2"
+appVersion: "2.26.3"
 
 dependencies:
 - name: minio

--- a/charts/terrakube/templates/configMap-ui.yaml
+++ b/charts/terrakube/templates/configMap-ui.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   my_server_block.conf: |
     server {
-        listen 80 default_server;
+        listen 0.0.0.0:8080;
         {{- if .Values.enableIPv6 }}
         listen [::]:80 default_server;
         {{- end }}

--- a/charts/terrakube/templates/deployment-ui.yaml
+++ b/charts/terrakube/templates/deployment-ui.yaml
@@ -41,7 +41,7 @@ spec:
           subPath: "env-config.js"
           readOnly: true
         - name: ui-web-config
-          mountPath: "/bitnami/nginx/conf/server_blocks/my_server_block.conf"
+          mountPath: "/opt/bitnami/nginx/conf/server_blocks/my_server_block.conf"
           subPath: my_server_block.conf
           readOnly: true
         {{- if .Values.ui.resources }}


### PR DESCRIPTION
This is related to the following issue #189 and these two PR :

- #190 change the incorrect path according the to Bitnami documentation [here](https://github.com/bitnami/containers/blob/main/bitnami/nginx/README.md#configuration) the correct path should be `/opt/bitnami/nginx/conf/server_blocks/my_server_block.conf`
- #183 added the default configuration using `listen 80 default_server;` but it was a little different from the one used when we create the container [here](https://github.com/terrakube-io/terrakube/blob/14c33621bf9fc171c36b04e1ef2c5b3e291b45b1/ui/conf/conf.d/bitnami.conf#L1) when we create the container using `listen 0.0.0.0:8080;`

When using `listen 80 default_server;` ngnix was creating the following issue:
Step 1:
![image](https://github.com/user-attachments/assets/c8ea58a9-dc28-4f8e-8a23-4c0ba8af8365)

Step 2:
Nginx error:
![image](https://github.com/user-attachments/assets/ab49b3e6-875b-4948-9a3b-b43cfaf47d28)





