### PR TITLE
Allow override registry probes

### DIFF
--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.2
+version: 4.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -69,20 +69,20 @@ spec:
           httpGet:
             path: /actuator/health
             port: 8075
-          failureThreshold: 30
-          periodSeconds: 10
+          failureThreshold: {{ .Values.registry.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.registry.startupProbe.periodSeconds }}
         livenessProbe:
           httpGet:
             path: /actuator/health/liveness
             port: 8075
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
             path: /actuator/health/readiness
             port: 8075
-          initialDelaySeconds: 120
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.registry.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.registry.readinessProbe.periodSeconds }}
         {{- with .Values.registry.containerSecurityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -316,6 +316,15 @@ registry:
   containerSecurityContext: {}
   imagePullSecrets: []
   initContainers: []
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 120
+    periodSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
 
 ## UI Properties
 ui:


### PR DESCRIPTION
Allow to override `initialDelaySeconds` and `periodSeconds` for registry deployment's probes