### PR TITLE
feat(executor): executor.cache block for provider + module caching (chart 4.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,13 @@ Once you have completed the above steps you can complete the file values.yaml to
 | executor.env                              | No       |                                                                        |
 | executor.volumes                          | No       |                                                                        |
 | executor.volumeMounts                     | No       |                                                                        |
+| executor.cache.enabled                    | No       | Cache providers/modules across jobs on a volume mounted in the executor |
+| executor.cache.path                       | No       | Mount point of the cache volume (default /home/cnb/.terraform.d)       |
+| executor.cache.sizeLimit                  | No       | emptyDir size limit (default 2Gi)                                      |
+| executor.cache.existingClaim              | No       | Use an existing PVC (RWX when replicaCount > 1) instead of an emptyDir |
+| executor.cache.providers                  | No       | Set TF_PLUGIN_CACHE_DIR (default true)                                 |
+| executor.cache.ignoreLockFile             | No       | Set TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1 (no committed lock file) |
+| executor.cache.modules                    | No       | Per-workspace TF_DATA_DIR via TerraformDataDirCacheRoot (executor support required) |
 | executor.properties.toolsRepository       | Yes      | Example: https://github.com/terrakube-io/terrakube-extensions          |
 | executor.properties.toolsBranch           | Yes      | Example: main                                                          |
 | executor.securityContext                  | No       | Fill securityContext field                                             |

--- a/charts/terrakube/Chart.yaml
+++ b/charts/terrakube/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.9
+version: 4.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -54,6 +54,21 @@ spec:
         - name: SERVICE_BINDING_ROOT
           value: /mnt/platform/bindings
         {{- end }}
+        {{- if (.Values.executor.cache).enabled }}
+        {{- $cachePath := .Values.executor.cache.path | default "/home/cnb/.terraform.d" | trimSuffix "/" }}
+        {{- if .Values.executor.cache.providers }}
+        - name: TF_PLUGIN_CACHE_DIR
+          value: {{ printf "%s/plugin-cache" $cachePath | quote }}
+        {{- if .Values.executor.cache.ignoreLockFile }}
+        - name: TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE
+          value: "1"
+        {{- end }}
+        {{- end }}
+        {{- if .Values.executor.cache.modules }}
+        - name: TerraformDataDirCacheRoot
+          value: {{ printf "%s/data" $cachePath | quote }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.executor.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -62,6 +77,10 @@ spec:
         - name: ca-certs
           mountPath: /mnt/platform/bindings/ca-certificates
           readOnly: true
+        {{- end }}
+        {{- if (.Values.executor.cache).enabled }}
+        - name: terraform-cache
+          mountPath: {{ .Values.executor.cache.path | default "/home/cnb/.terraform.d" | trimSuffix "/" | quote }}
         {{- end }}
         {{- with .Values.executor.volumeMounts }}
         {{- toYaml . | nindent 8 }}
@@ -117,6 +136,18 @@ spec:
       - name: ca-certs
         secret:
           secretName: terrakube-ca-secrets
+      {{- end }}
+      {{- if (.Values.executor.cache).enabled }}
+      - name: terraform-cache
+        {{- if .Values.executor.cache.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.executor.cache.existingClaim | quote }}
+        {{- else }}
+        emptyDir:
+          {{- with .Values.executor.cache.sizeLimit }}
+          sizeLimit: {{ . | quote }}
+          {{- end }}
+        {{- end }}
       {{- end }}
       {{- with .Values.executor.volumes }}
       {{- toYaml . | nindent 6 }}

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -32,9 +32,26 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.executor.initContainers }}
+      {{- if or (.Values.executor.cache).enabled .Values.executor.initContainers }}
       initContainers:
+      {{- if (.Values.executor.cache).enabled }}
+      {{- $cachePath := .Values.executor.cache.path | default "/home/cnb/.terraform.d" | trimSuffix "/" }}
+      # Terraform/OpenTofu refuse a TF_PLUGIN_CACHE_DIR that does not exist and a fresh volume is
+      # empty, so create the cache sub-directories (as the executor's own user) before the executor starts.
+      - name: init-terraform-cache
+        image: {{ .Values.executor.image }}:{{ default .Chart.AppVersion .Values.executor.version }}
+        command: ["sh", "-c", {{ printf "mkdir -p %s/plugin-cache %s/data" $cachePath $cachePath | quote }}]
+        volumeMounts:
+        - name: terraform-cache
+          mountPath: {{ $cachePath | quote }}
+        {{- with .Values.executor.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.executor.initContainers }}
         {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- end }}
       containers:
       - name: terrakube-executor

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -634,6 +634,32 @@
                 },
                 "version": {
                     "type": "string"
+                },
+                "cache": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "sizeLimit": {
+                            "type": "string"
+                        },
+                        "existingClaim": {
+                            "type": "string"
+                        },
+                        "providers": {
+                            "type": "boolean"
+                        },
+                        "ignoreLockFile": {
+                            "type": "boolean"
+                        },
+                        "modules": {
+                            "type": "boolean"
+                        }
+                    }
                 }
             }
         },

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -321,6 +321,28 @@ executor:
     # Longest a single job may run before this pod is marked unhealthy (liveness) so
     # Kubernetes restarts it - covers a hung terraform process or infinite-looping hook script.
     maxJobDurationMinutes: "360"
+  # Cache what terraform/tofu init downloads, across jobs. Every job runs in a fresh
+  # clone, so without a cache the providers and the modules are fetched again on every run.
+  cache:
+    enabled: false
+    # Mount point of the cache volume inside the executor container.
+    path: "/home/cnb/.terraform.d"
+    # emptyDir size limit (ignored when existingClaim is set). Lives as long as the pod.
+    sizeLimit: "2Gi"
+    # Use an existing PersistentVolumeClaim instead of an emptyDir so the cache survives
+    # pod restarts. Must be ReadWriteMany when replicaCount > 1.
+    existingClaim: ""
+    # Provider plugin cache: TF_PLUGIN_CACHE_DIR=<path>/plugin-cache
+    providers: true
+    # Terraform/OpenTofu only reuse a cached provider that is already recorded in the
+    # workspace's .terraform.lock.hcl. Enable when your repositories do not commit the lock
+    # file (sets TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1).
+    ignoreLockFile: false
+    # Per-workspace data directory: TerraformDataDirCacheRoot=<path>/data, which the executor
+    # turns into TF_DATA_DIR=<path>/data/<organization>/<workspace> so the modules AND the
+    # providers are reused by the next job of the same workspace. Requires an executor that
+    # supports TerraformDataDirCacheRoot (ignored by older images).
+    modules: true
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []


### PR DESCRIPTION
## Summary

Adds an `executor.cache` block that sets up job-to-job caching for the executor in one place:

```yaml
executor:
  cache:
    enabled: true
    path: /home/cnb/.terraform.d   # mount point of the cache volume
    sizeLimit: 2Gi                 # emptyDir size; or
    existingClaim: ""              #   an existing PVC (RWX when replicaCount > 1)
    providers: true                # TF_PLUGIN_CACHE_DIR=<path>/plugin-cache
    ignoreLockFile: false          # TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE=1
    modules: true                  # TerraformDataDirCacheRoot=<path>/data  (executor support: terrakube-io/terrakube#3478)
```

Today the *Provider Cache* docs tell users to add a volume, a mount **and** the env var by hand; it is easy to end up with the volume mounted and the variable missing (which is exactly what we found in our own deployment — the cache dir stayed empty). `modules: true` wires the new executor setting that also keeps the modules between jobs of the same workspace; older executor images simply ignore that variable.

Disabled by default: rendering is byte-for-byte unchanged for existing values files (`helm template` diff is empty). `values.schema.json`, the README values table and the chart version (4.8.0) are updated.

## Test plan

- [x] `helm lint`
- [x] `helm template` with the default values → no cache env/volume rendered
- [x] `--set executor.cache.enabled=true --set executor.cache.ignoreLockFile=true` → emptyDir volume with sizeLimit, mount at `/home/cnb/.terraform.d`, the three env vars
- [x] `--set executor.cache.existingClaim=tf-cache --set executor.cache.path=/cache/ --set executor.cache.providers=false` → PVC volume, trailing slash trimmed, only `TerraformDataDirCacheRoot` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
