### PR TITLE
feat(configMap,deployment,gatewayApi): improve storage, image pulls, ephemeral execution, and Gateway API

### DIFF
--- a/charts/terrakube/templates/configMap-api.yaml
+++ b/charts/terrakube/templates/configMap-api.yaml
@@ -38,7 +38,7 @@ data:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   StorageType: 'AZURE'
   AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'

--- a/charts/terrakube/templates/configMap-executor.yaml
+++ b/charts/terrakube/templates/configMap-executor.yaml
@@ -38,7 +38,7 @@ data:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   TerraformStateType: 'AzureTerraformStateImpl'
   AzureTerraformStateResourceGroup: '{{ .Values.storage.azure.storageAccountResourceGroup }}'

--- a/charts/terrakube/templates/configMap-executor.yaml
+++ b/charts/terrakube/templates/configMap-executor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.executor.enabled -}}
+{{- if or .Values.executor.enabled .Values.api.ephemeralExecution.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/terrakube/templates/configMap-registry.yaml
+++ b/charts/terrakube/templates/configMap-registry.yaml
@@ -24,7 +24,7 @@ data:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   RegistryStorageType: 'AzureStorageImpl'
   AzureAccountName: '{{ .Values.storage.azure.storageAccountName }}'

--- a/charts/terrakube/templates/deployment-api.yaml
+++ b/charts/terrakube/templates/deployment-api.yaml
@@ -39,6 +39,7 @@ spec:
       containers:
       - name: terrakube-api
         image: {{ .Values.api.image }}:{{ default .Chart.AppVersion .Values.api.version }}
+        imagePullPolicy: {{ .Values.api.imagePullPolicy | default "IfNotPresent" }}
         {{- if .Values.api.resources }}
         resources: {{- toYaml .Values.api.resources | nindent 12 }}
         {{- end }}

--- a/charts/terrakube/templates/deployment-executor.yaml
+++ b/charts/terrakube/templates/deployment-executor.yaml
@@ -39,6 +39,7 @@ spec:
       containers:
       - name: terrakube-executor
         image: {{ .Values.executor.image }}:{{ default .Chart.AppVersion .Values.executor.version }}
+        imagePullPolicy: {{ .Values.executor.imagePullPolicy | default "IfNotPresent" }}
         {{- if .Values.executor.resources }}
         resources: {{- toYaml .Values.executor.resources | nindent 12 }}
         {{- end }}

--- a/charts/terrakube/templates/deployment-openldap.yaml
+++ b/charts/terrakube/templates/deployment-openldap.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
       - name: terrakube-openldap
         image: {{ .Values.openldap.image }}:{{ .Values.openldap.version }}
+        imagePullPolicy: {{ .Values.openldap.imagePullPolicy | default "IfNotPresent" }}
         env:
         - name: LDAP_ADMIN_USERNAME
           value: {{ .Values.openldap.adminUser }}

--- a/charts/terrakube/templates/deployment-registry.yaml
+++ b/charts/terrakube/templates/deployment-registry.yaml
@@ -39,6 +39,7 @@ spec:
       containers:
       - name: terrakube-registry
         image: {{ .Values.registry.image }}:{{ default .Chart.AppVersion .Values.registry.version }}
+        imagePullPolicy: {{ .Values.registry.imagePullPolicy | default "IfNotPresent" }}
         {{- if .Values.registry.resources }}
         resources: {{- toYaml .Values.registry.resources | nindent 12 }}
         {{- end }}

--- a/charts/terrakube/templates/deployment-ui.yaml
+++ b/charts/terrakube/templates/deployment-ui.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
       - name: terrakube-ui
         image: {{ .Values.ui.image }}:{{ default .Chart.AppVersion .Values.ui.version }}
+        imagePullPolicy: {{ .Values.ui.imagePullPolicy | default "IfNotPresent" }}
         volumeMounts:
         - name: ui-config
           mountPath: "/usr/share/nginx/html/env-config.js"

--- a/charts/terrakube/templates/httproute-api.yaml
+++ b/charts/terrakube/templates/httproute-api.yaml
@@ -14,7 +14,7 @@ spec:
   hostnames:
     - {{ . | quote }}
 {{- end }}
-{{- with .Values.ingress.gatewayapi.gateways}}
+{{- with .Values.ingress.api.gateways | default .Values.ingress.gatewayapi.gateways}}
   parentRefs: {{- . | toYaml | nindent 4 }}
 {{- end }}
   rules:

--- a/charts/terrakube/templates/httproute-executor.yaml
+++ b/charts/terrakube/templates/httproute-executor.yaml
@@ -14,7 +14,7 @@ spec:
   hostnames:
     - {{ . | quote }}
 {{- end }}
-{{- with .Values.ingress.gatewayapi.gateways}}
+{{- with .Values.ingress.executor.gateways | default .Values.ingress.gatewayapi.gateways}}
   parentRefs: {{- . | toYaml | nindent 4 }}
 {{- end }}
   rules:

--- a/charts/terrakube/templates/httproute-registry.yaml
+++ b/charts/terrakube/templates/httproute-registry.yaml
@@ -14,7 +14,7 @@ spec:
   hostnames:
     - {{ . | quote }}
 {{- end }}
-{{- with .Values.ingress.gatewayapi.gateways}}
+{{- with .Values.ingress.registry.gateways | default .Values.ingress.gatewayapi.gateways}}
   parentRefs: {{- . | toYaml | nindent 4 }}
 {{- end }}
   rules:

--- a/charts/terrakube/templates/httproute-ui.yaml
+++ b/charts/terrakube/templates/httproute-ui.yaml
@@ -14,7 +14,7 @@ spec:
   hostnames:
     - {{ . | quote }}
 {{- end }}
-{{- with .Values.ingress.gatewayapi.gateways}}
+{{- with .Values.ingress.ui.gateways | default .Values.ingress.gatewayapi.gateways}}
   parentRefs: {{- . | toYaml | nindent 4 }}
 {{- end }}
   rules:

--- a/charts/terrakube/templates/referencegrant.yaml
+++ b/charts/terrakube/templates/referencegrant.yaml
@@ -1,0 +1,25 @@
+{{- $gateways := concat .Values.ingress.gatewayapi.gateways .Values.ingress.ui.gateways .Values.ingress.api.gateways .Values.ingress.registry.gateways .Values.ingress.executor.gateways }}
+{{- if and (eq .Values.ingress.controller "gatewayapi") .Values.ingress.gatewayapi.createReferenceGrant }}
+{{- $uniqueNamespaces := dict }}
+{{- range $gateways }}
+{{- if and .namespace (not (hasKey $uniqueNamespaces .namespace)) }}
+{{- $_ := set $uniqueNamespaces .namespace true }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ $.Values.name }}-allow-gateway-tls-{{ .namespace | replace "." "-" | trunc 20 | trimSuffix "-" }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "terrakube.labels" $ | nindent 4 }}
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: {{ .namespace }}
+  to:
+  - group: ""
+    kind: Secret
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/terrakube/templates/secrets-api.yaml
+++ b/charts/terrakube/templates/secrets-api.yaml
@@ -26,7 +26,7 @@ stringData:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}

--- a/charts/terrakube/templates/secrets-executor.yaml
+++ b/charts/terrakube/templates/secrets-executor.yaml
@@ -26,7 +26,7 @@ stringData:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   AzureTerraformStateStorageAccessKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   AzureTerraformOutputAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'

--- a/charts/terrakube/templates/secrets-registry.yaml
+++ b/charts/terrakube/templates/secrets-registry.yaml
@@ -19,7 +19,7 @@ stringData:
 
   {{- else }}
 
-  {{- if and (.Values.storage.azure).storageAccountName (.Values.storage.azure).storageAccountAccessKey }}
+  {{- if (.Values.storage.azure).storageAccountName }}
   #Azure Storage
   AzureAccountKey: '{{ .Values.storage.azure.storageAccountAccessKey }}'
   {{- end }}

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -677,6 +677,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "gateways": {
+                            "type": "array"
+                        },
                         "ingressClassName": {
                             "type": "string"
                         },
@@ -803,6 +806,9 @@
                         },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "gateways": {
+                            "type": "array"
                         },
                         "ingressClassName": {
                             "type": "string"
@@ -968,6 +974,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "gateways": {
+                            "type": "array"
+                        },
                         "ingressClassName": {
                             "type": "string"
                         },
@@ -1004,6 +1013,9 @@
                         },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "gateways": {
+                            "type": "array"
                         },
                         "ingressClassName": {
                             "type": "string"

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -95,6 +95,9 @@
                 "imagePullSecrets": {
                     "type": "array"
                 },
+                "imagePullPolicy": {
+                    "type": "string"
+                },
                 "initContainers": {
                     "type": "array"
                 },
@@ -519,6 +522,9 @@
                 },
                 "imagePullSecrets": {
                     "type": "array"
+                },
+                "imagePullPolicy": {
+                    "type": "string"
                 },
                 "initContainers": {
                     "type": "array"
@@ -1094,6 +1100,9 @@
                 "imagePullSecrets": {
                     "type": "array"
                 },
+                "imagePullPolicy": {
+                    "type": "string"
+                },
                 "initContainers": {
                     "type": "array"
                 },
@@ -1167,6 +1176,9 @@
                 },
                 "imagePullSecrets": {
                     "type": "array"
+                },
+                "imagePullPolicy": {
+                    "type": "string"
                 },
                 "initContainers": {
                     "type": "array"
@@ -1407,6 +1419,9 @@
                 },
                 "imagePullSecrets": {
                     "type": "array"
+                },
+                "imagePullPolicy": {
+                    "type": "string"
                 },
                 "initContainers": {
                     "type": "array"

--- a/charts/terrakube/values.schema.json
+++ b/charts/terrakube/values.schema.json
@@ -838,6 +838,9 @@
                         },
                         "gateways": {
                             "type": "array"
+                        },
+                        "createReferenceGrant": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -429,6 +429,8 @@ ingress:
   gatewayapi:
     apiVersion: v1beta1
     enabled: false
+    # Enable when a Gateway in another namespace needs to reference a TLS Secret in this namespace and no external ReferenceGrant exists.
+    createReferenceGrant: false
     gateways: []
     annotations: {}
 

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -26,6 +26,7 @@ openldap:
   image: "bitnamilegacy/openldap"
   version: "latest"
   imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
   initContainers: []
   podLabels: {}
   podAnnotations: {}
@@ -244,6 +245,7 @@ api:
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
   initContainers: []
   podDisruptionBudget:
     enabled: false
@@ -324,6 +326,8 @@ executor:
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []
+  # It may be necessary to set this to Always when using a custom executor image during development and testing.
+  imagePullPolicy: IfNotPresent
   initContainers: []
   podDisruptionBudget:
     enabled: false
@@ -373,6 +377,7 @@ registry:
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
   initContainers: []
   podDisruptionBudget:
     enabled: false
@@ -405,6 +410,7 @@ ui:
   securityContext: {}
   containerSecurityContext: {}
   imagePullSecrets: []
+  imagePullPolicy: IfNotPresent
   initContainers: []
   podDisruptionBudget:
     enabled: false

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -434,6 +434,14 @@ ingress:
 
   ui:
     enabled: true
+    gateways: []
+    # Custom parentRef configuration for this endpoint, such as sectionName.
+    # gateways:
+    #   - group: gateway.networking.k8s.io
+    #     kind: Gateway
+    #     name: internal-gateway
+    #     namespace: gateway-system
+    #     sectionName: https-terrakube-ui
     domain: "terrakube-ui.minikube.net"
     path: "/"
     pathType: "Prefix"
@@ -445,6 +453,14 @@ ingress:
   
   api:
     enabled: true
+    gateways: []
+    # Custom parentRef configuration for this endpoint, such as sectionName.
+    # gateways:
+    #   - group: gateway.networking.k8s.io
+    #     kind: Gateway
+    #     name: internal-gateway
+    #     namespace: gateway-system
+    #     sectionName: https-terrakube-api
     domain: "terrakube-api.minikube.net"
     path: "/"
     pathType: "Prefix"
@@ -457,6 +473,14 @@ ingress:
 
   registry:
     enabled: true
+    gateways: []
+    # Custom parentRef configuration for this endpoint, such as sectionName.
+    # gateways:
+    #   - group: gateway.networking.k8s.io
+    #     kind: Gateway
+    #     name: internal-gateway
+    #     namespace: gateway-system
+    #     sectionName: https-terrakube-reg
     domain: "terrakube-reg.minikube.net"
     path: "/"
     pathType: "Prefix"
@@ -475,6 +499,14 @@ ingress:
       nginx.ingress.kubernetes.io/proxy-set-headers: "terrakube/custom-headers"
   executor:
     enabled: false
+    gateways: []
+    # Custom parentRef configuration for this endpoint, such as sectionName.
+    # gateways:
+    #   - group: gateway.networking.k8s.io
+    #     kind: Gateway
+    #     name: internal-gateway
+    #     namespace: gateway-system
+    #     sectionName: https-terrakube-executor
     domain: "terrakube-executor.minikube.net"
     path: "/"
     pathType: "Prefix"

--- a/charts/terrakube/values.yaml
+++ b/charts/terrakube/values.yaml
@@ -228,6 +228,7 @@ api:
     enabled: false
     secretName:
       - terrakube-executor-secrets
+    # Set to terrakube-executor-config to reuse the same configuration for ephemeral executions.
     configMapName: ""
     podAnnotations: {}
   secrets:


### PR DESCRIPTION
## Summary
 
- Allow Azure storage configuration when credentials are provided through an existing Secret.
- Add configurable `imagePullPolicy` to all Terrakube and OpenLDAP Deployments, defaulting to `IfNotPresent`.
- Allow the executor ConfigMap to be reused by ephemeral executions.
- Support custom Gateway API parent references per endpoint:
  - UI
  - API
  - Registry
  - Executor
- Preserve the global Gateway API configuration as a fallback for HTTPRoutes.
- Add optional `ReferenceGrant` generation for cross-namespace Gateway TLS Secret references.
- Keep `createReferenceGrant` disabled by default and allow it to be enabled explicitly.
- Add the new configuration options to `values.schema.json` and document examples in `values.yaml`.
 